### PR TITLE
add MCP server badge

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -11,6 +11,8 @@ A Model Context Protocol (MCP) server implementation for interfacing with Kobold
 - Built on the official MCP SDK
 - TypeScript implementation
 
+<a href="https://glama.ai/mcp/servers/a2xd4hoij7"><img width="380" height="200" src="https://glama.ai/mcp/servers/a2xd4hoij7/badge" alt="Kobold Server MCP server" /></a>
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
This PR adds a badge for the [Kobold MCP Server](https://glama.ai/mcp/servers/a2xd4hoij7) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/a2xd4hoij7"><img width="380" height="200" src="https://glama.ai/mcp/servers/a2xd4hoij7/badge" alt="Kobold Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.